### PR TITLE
Added no-op artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Add it to your build.gradle:
 
 ```groovy
 dependencies{
-    compile 'com.sloydev:preferator:1.0.0'
+    debugCompile 'com.sloydev:preferator:1.0.0'
+    releaseCompile 'com.sloydev:preferator-no-op:1.0.0'
 }
 ```
 

--- a/library-no-op/build.gradle
+++ b/library-no-op/build.gradle
@@ -1,22 +1,21 @@
-apply plugin: 'com.android.application'
+apply plugin: 'com.android.library'
+apply plugin: 'com.novoda.bintray-release'
 
 sourceCompatibility = 1.7
 
 android {
     compileSdkVersion 23
     buildToolsVersion "23.0.1"
+
     defaultConfig {
-        applicationId "com.sloydev.preferator.demo"
         minSdkVersion 15
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"
+
     }
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
+    lintOptions {
+        abortOnError false
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
@@ -26,6 +25,14 @@ android {
 
 dependencies {
     compile 'com.android.support:appcompat-v7:23.0.0'
-    debugCompile project(':library')
-    releaseCompile project(':library-no-op')
+
+}
+
+publish {
+    userOrg = 'sloy'
+    groupId = 'com.sloydev'
+    artifactId = 'preferator-no-op'
+    publishVersion = '1.0.0'
+    desc = 'Edit your app\'s SharedPreferences from your device'
+    website = 'https://github.com/sloy/preferator'
 }

--- a/library-no-op/src/main/AndroidManifest.xml
+++ b/library-no-op/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.sloydev.library_no_op">
+
+</manifest>

--- a/library-no-op/src/main/java/com/sloydev/preferator/Preferator.java
+++ b/library-no-op/src/main/java/com/sloydev/preferator/Preferator.java
@@ -1,0 +1,11 @@
+package com.sloydev.preferator;
+
+
+import android.content.Context;
+
+public class Preferator {
+
+    public static void launch(Context context) {
+        // no-op
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':sample', ':library'
+include ':sample', ':library', ':library-no-op'


### PR DESCRIPTION
This artifact includes the same public class and method than the normal library, but has no code at all.
It's useful to avoid including the library's code in the release APK.