### PR TITLE
Allow to collapse sections

### DIFF
--- a/library/src/main/java/com/sloydev/preferator/PreferatorActivity.kt
+++ b/library/src/main/java/com/sloydev/preferator/PreferatorActivity.kt
@@ -12,6 +12,7 @@ import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import android.widget.TextView
 import com.sloydev.preferator.editor.*
 import java.io.File
@@ -70,15 +71,19 @@ class PreferatorActivity : AppCompatActivity() {
 
     private fun addSection(sectionTitle: String, entries: List<Pair<String, *>>, preferences: SharedPreferences) {
         val sectionView = LayoutInflater.from(this).inflate(R.layout.item_section, sectionsView, false)
+        val sectionNameContainer = sectionView.findViewById(R.id.section_name_container)
         val sectionNameView = sectionView.findViewById(R.id.section_name) as TextView
+        val sectionArrowView = sectionView.findViewById(R.id.section_arrow) as ImageView
         val itemsView = sectionView.findViewById(R.id.section_items) as ViewGroup
 
         sectionNameView.text = sectionTitle
-        sectionNameView.setOnClickListener {
+        sectionNameContainer.setOnClickListener {
             if (itemsView.visibility == View.VISIBLE) {
                 itemsView.visibility = View.GONE
+                sectionArrowView.setImageResource(R.drawable.ic_arrow_expand_black_24dp)
             } else {
                 itemsView.visibility = View.VISIBLE
+                sectionArrowView.setImageResource(R.drawable.ic_arrow_collapse_black_24dp)
             }
         }
 

--- a/library/src/main/java/com/sloydev/preferator/PreferatorActivity.kt
+++ b/library/src/main/java/com/sloydev/preferator/PreferatorActivity.kt
@@ -74,6 +74,14 @@ class PreferatorActivity : AppCompatActivity() {
         val itemsView = sectionView.findViewById(R.id.section_items) as ViewGroup
 
         sectionNameView.text = sectionTitle
+        sectionNameView.setOnClickListener {
+            if (itemsView.visibility == View.VISIBLE) {
+                itemsView.visibility = View.GONE
+            } else {
+                itemsView.visibility = View.VISIBLE
+            }
+        }
+
         for (pref in entries) {
             val prefKey = pref.first
             val prefValue = pref.second

--- a/library/src/main/res/drawable/ic_arrow_collapse_black_24dp.xml
+++ b/library/src/main/res/drawable/ic_arrow_collapse_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M7.41,15.41L12,10.83l4.59,4.58L18,14l-6,-6 -6,6z"/>
+</vector>

--- a/library/src/main/res/drawable/ic_arrow_expand_black_24dp.xml
+++ b/library/src/main/res/drawable/ic_arrow_expand_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M7.41,7.84L12,12.42l4.59,-4.58L18,9.25l-6,6 -6,-6z"/>
+</vector>

--- a/library/src/main/res/drawable/ic_more_vert_black_24dp.xml
+++ b/library/src/main/res/drawable/ic_more_vert_black_24dp.xml
@@ -4,6 +4,6 @@
         android:viewportWidth="24.0"
         android:viewportHeight="24.0">
     <path
-        android:fillColor="@color/black_54"
+        android:fillColor="#757575"
         android:pathData="M12,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM12,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM12,16c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z"/>
 </vector>

--- a/library/src/main/res/layout/item_section.xml
+++ b/library/src/main/res/layout/item_section.xml
@@ -4,21 +4,21 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginBottom="@dimen/margin_medium"
-    android:animateLayoutChanges="true"
     android:background="@color/white"
     android:elevation="4dp"
     android:orientation="vertical"
-    tools:context="com.sloydev.preferator.PreferatorActivity"
-    tools:showIn="@layout/activity_prefereitor">
+    >
 
     <TextView
         android:id="@+id/section_name"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="@dimen/margin_medium"
-        android:layout_marginTop="@dimen/margin_medium"
-        android:text="file name"
-        android:textAppearance="@style/section_title_text_appearance" />
+        android:background="?selectableItemBackground"
+        android:gravity="center_vertical"
+        android:minHeight="48dp"
+        android:paddingLeft="@dimen/margin_medium"
+        android:textAppearance="@style/section_title_text_appearance"
+        tools:text="file name"/>
 
     <LinearLayout
         android:id="@+id/section_items"

--- a/library/src/main/res/layout/item_section.xml
+++ b/library/src/main/res/layout/item_section.xml
@@ -9,16 +9,35 @@
     android:orientation="vertical"
     >
 
-    <TextView
-        android:id="@+id/section_name"
+    <LinearLayout
+        android:id="@+id/section_name_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?selectableItemBackground"
-        android:gravity="center_vertical"
-        android:minHeight="48dp"
+        android:paddingTop="4dp"
         android:paddingLeft="@dimen/margin_medium"
-        android:textAppearance="@style/section_title_text_appearance"
-        tools:text="file name"/>
+        android:paddingRight="@dimen/margin_small">
+
+        <TextView
+            android:id="@+id/section_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center_vertical"
+            android:minHeight="48dp"
+            android:textAppearance="@style/section_title_text_appearance"
+            tools:text="file name"/>
+
+        <ImageView
+            android:id="@+id/section_arrow"
+            android:layout_marginLeft="@dimen/margin_small"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:src="@drawable/ic_arrow_collapse_black_24dp"
+            android:tint="?colorAccent"
+            />
+    </LinearLayout>
 
     <LinearLayout
         android:id="@+id/section_items"


### PR DESCRIPTION
With this change users can collapse sections by clicking on the title.
This let's them navigate more easily between the different preferences when the app has many of them.